### PR TITLE
added error handling divide by zero

### DIFF
--- a/src/com/jwetherell/algorithms/mathematics/Division.java
+++ b/src/com/jwetherell/algorithms/mathematics/Division.java
@@ -3,11 +3,19 @@ package com.jwetherell.algorithms.mathematics;
 public class Division {
 
     public static final long division(int a, int b) {
+        //error handling quiz 2
+        if (b == 0) {
+            throw new IllegalArgumentException("Not allowed.");
+            } 
         long result = ((long) a) / ((long) b);
         return result;
     }
 
     public static final long divisionUsingLoop(int a, int b) {
+        //error handling quiz 2
+        if (b == 0) {
+            throw new IllegalArgumentException("Not allowed.");
+            } 
         int absA = Math.abs(a);
         int absB = Math.abs(b);
 
@@ -22,6 +30,10 @@ public class Division {
     }
 
     public static final long divisionUsingRecursion(int a, int b) {
+        //error handling quiz 2
+        if (b == 0) {
+            throw new IllegalArgumentException("Not allowed.");
+            } 
         int absA = Math.abs(a);
         int absB = Math.abs(b);
 
@@ -38,6 +50,10 @@ public class Division {
     }
 
     public static final long divisionUsingMultiplication(int a, int b) {
+        //error handling quiz 2
+        if (b == 0) {
+            throw new IllegalArgumentException("Not allowed.");
+            } 
         int absA = Math.abs(a);
         int absB = Math.abs(b);
 
@@ -55,6 +71,10 @@ public class Division {
     }
 
     public static final long divisionUsingShift(int a, int b) {
+        //error handling quiz 2
+        if (b == 0) {
+            throw new IllegalArgumentException("Not allowed.");
+            } 
         int absA = Math.abs(a);
         int absB = Math.abs(b);
         int tempA, tempB, counter;
@@ -76,6 +96,10 @@ public class Division {
     }
 
     public static final long divisionUsingLogs(int a, int b) {
+        //error handling quiz 2
+        if (b == 0) {
+            throw new IllegalArgumentException("Not allowed.");
+            } 
         long absA = Math.abs(a);
         long absB = Math.abs(b);
         double logBase10A = Math.log10(absA);


### PR DESCRIPTION
Added error handling for divide by zero cases

As seen in the code: 

//error handling quiz 2
        if (b == 0) {
            throw new IllegalArgumentException("Not allowed.");
            } 

This will allow the code to throw the Illegal Argument Exception.